### PR TITLE
Change Data parameter in parser with Response

### DIFF
--- a/DemoApp/DemoApp/Network/Examples/PartialDataParser.swift
+++ b/DemoApp/DemoApp/Network/Examples/PartialDataParser.swift
@@ -2,9 +2,9 @@ import Foundation
 import JNetworkingKit
 
 class PartialDataRequestParser: RequestParserType {
-    func parse(data: Data) throws -> [String] {
+    func parse(response: Response) throws -> [String] {
         do {
-            let jsonResponse = try JSONDecoder().decode([String: Result].self, from: data)
+            let jsonResponse = try JSONDecoder().decode([String: Result].self, from: response.data)
             let partialData: [String] =  jsonResponse["first_half"] ?? []
             return partialData
         } catch let error {

--- a/DemoApp/DemoApp/Network/ImageDownload/ImageRequestOperation.swift
+++ b/DemoApp/DemoApp/Network/ImageDownload/ImageRequestOperation.swift
@@ -3,7 +3,7 @@ import UIKit
 import JNetworkingKit
 
 class ImageOperation: NSObject, RequestOperationType {
-    typealias Result = UIImage
+    typealias Result = ImageParser.Result
 
     var executor = RequestExecutor()
     var parser = ImageParser()

--- a/DemoApp/DemoApp/Network/ImageDownload/ImageRequestParser.swift
+++ b/DemoApp/DemoApp/Network/ImageDownload/ImageRequestParser.swift
@@ -3,8 +3,10 @@ import UIKit
 import JNetworkingKit
 
 class ImageParser: RequestParserType {
-    func parse(data: Data) throws -> UIImage {
-        guard let image = UIImage(data: data) else {
+    typealias Result = UIImage
+
+    func parse(response: Response) throws -> UIImage {
+        guard let image = UIImage(data: response.data) else {
             throw RequestParserError.invalidData(parserError: nil)
         }
 

--- a/JNetworkingKit/JNetworkingKitTests/Mocks/RequestParserMock.swift
+++ b/JNetworkingKit/JNetworkingKitTests/Mocks/RequestParserMock.swift
@@ -25,8 +25,10 @@ class RequestParserMock {
 }
 
 extension RequestParserMock: RequestParserType {
-    func parse(data: Data) throws -> String {
-        captures.parse = Captures.Parse(data: data)
+    typealias Result = String
+
+    func parse(response: Response) throws -> String {
+        captures.parse = Captures.Parse(data: response.data)
 
         if let error = stubs.parse.error {
             throw error

--- a/JNetworkingKit/JNetworkingKitTests/Tests/Components/RequestOperationTypeSpec.swift
+++ b/JNetworkingKit/JNetworkingKitTests/Tests/Components/RequestOperationTypeSpec.swift
@@ -140,7 +140,7 @@ class RequestOperationTypeSpec: QuickSpec {
 }
 
 class ConcreteRequestOperation: RequestOperationType {
-    typealias Result = String
+    typealias Result = RequestParserMock.Result
 
     var executor: RequestExecutorMock
     var parser: RequestParserMock

--- a/JNetworkingKit/Source/Components/RequestOperation/RequestOperationType.swift
+++ b/JNetworkingKit/Source/Components/RequestOperation/RequestOperationType.swift
@@ -23,7 +23,7 @@ public extension RequestOperationType {
             onSuccess: { response in
                 do {
                     try self.validator.validate(response: response)
-                    let result = try self.parser.parse(data: response.data)
+                    let result = try self.parser.parse(response: response)
                     DispatchQueue.main.async {
                         onSuccess?(result)
                     }

--- a/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Codable.swift
+++ b/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Codable.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public extension RequestParserType where Result: Codable {
-    public func parse(data: Data) throws -> Result {
+    public func parse(response: Response) throws -> Result {
         do {
-            return try JSONDecoder().decode(Result.self, from: data)
+            return try JSONDecoder().decode(Result.self, from: response.data)
         } catch let error {
             throw RequestParserError.invalidData(parserError: error)
         }

--- a/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Void.swift
+++ b/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Void.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public extension RequestParserType where Result == Void {
-    public func parse(data: Data) throws {}
+    public func parse(response: Response) throws {}
 }

--- a/JNetworkingKit/Source/Components/RequestParser/RequestParserType.swift
+++ b/JNetworkingKit/Source/Components/RequestParser/RequestParserType.swift
@@ -8,5 +8,5 @@ public enum RequestParserError: Error {
 public protocol RequestParserType {
     associatedtype Result
 
-    func parse(data: Data) throws -> Result
+    func parse(response: Response) throws -> Result
 }


### PR DESCRIPTION
This request will revert a change made to change the parse parameter from Response to Data. Without the Response object, it is not possible to parse response headers.