### PR TITLE
Adding a generic AnyRequestParser and VoidRequestParser

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		A3E204712174AE8400A796A6 /* ImageRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E2046F2174AE8400A796A6 /* ImageRequestParser.swift */; };
 		A3E204732174B14700A796A6 /* MovieGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E204722174B14700A796A6 /* MovieGateway.swift */; };
 		A3E204762174B16900A796A6 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E204752174B16900A796A6 /* Movie.swift */; };
-		A3E2047A2174B1F100A796A6 /* MovieDetailRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E204782174B1F100A796A6 /* MovieDetailRequestParser.swift */; };
 		A3E2047B2174B1F100A796A6 /* MovieDetailRequestOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E204792174B1F100A796A6 /* MovieDetailRequestOperation.swift */; };
 		A3E2047F2174B2F400A796A6 /* MovieRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E2047E2174B2F400A796A6 /* MovieRouter.swift */; };
 		A3E204872174B9E500A796A6 /* CacheRequestExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E204842174B9E500A796A6 /* CacheRequestExecutor.swift */; };
@@ -49,7 +48,6 @@
 		A3E2046F2174AE8400A796A6 /* ImageRequestParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageRequestParser.swift; sourceTree = "<group>"; };
 		A3E204722174B14700A796A6 /* MovieGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieGateway.swift; sourceTree = "<group>"; };
 		A3E204752174B16900A796A6 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
-		A3E204782174B1F100A796A6 /* MovieDetailRequestParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieDetailRequestParser.swift; sourceTree = "<group>"; };
 		A3E204792174B1F100A796A6 /* MovieDetailRequestOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieDetailRequestOperation.swift; sourceTree = "<group>"; };
 		A3E2047E2174B2F400A796A6 /* MovieRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieRouter.swift; sourceTree = "<group>"; };
 		A3E204842174B9E500A796A6 /* CacheRequestExecutor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheRequestExecutor.swift; sourceTree = "<group>"; };
@@ -179,7 +177,6 @@
 			isa = PBXGroup;
 			children = (
 				A3E204792174B1F100A796A6 /* MovieDetailRequestOperation.swift */,
-				A3E204782174B1F100A796A6 /* MovieDetailRequestParser.swift */,
 			);
 			path = MovieDetail;
 			sourceTree = "<group>";
@@ -361,7 +358,6 @@
 				A3E204882174B9E500A796A6 /* HeaderRequestValidator.swift in Sources */,
 				A3E204672174949500A796A6 /* SecondViewController.swift in Sources */,
 				A3E2046B2174966000A796A6 /* Gateway.swift in Sources */,
-				A3E2047A2174B1F100A796A6 /* MovieDetailRequestParser.swift in Sources */,
 				A3E204712174AE8400A796A6 /* ImageRequestParser.swift in Sources */,
 				A3E204702174AE8400A796A6 /* ImageRequestOperation.swift in Sources */,
 				078A15F3221ECFE200C67339 /* PartialDataParser.swift in Sources */,

--- a/DemoApp/DemoApp/Network/Examples/PartialDataParser.swift
+++ b/DemoApp/DemoApp/Network/Examples/PartialDataParser.swift
@@ -2,9 +2,9 @@ import Foundation
 import JNetworkingKit
 
 class PartialDataRequestParser: RequestParserType {
-    func parse(data: Data) throws -> [String] {
+    func parse(response: Response) throws -> [String] {
         do {
-            let jsonResponse = try JSONDecoder().decode([String: Result].self, from: data)
+            let jsonResponse = try JSONDecoder().decode([String: Result].self, from: response.data)
             let partialData: [String] =  jsonResponse["first_half"] ?? []
             return partialData
         } catch let error {

--- a/DemoApp/DemoApp/Network/ImageDownload/ImageRequestOperation.swift
+++ b/DemoApp/DemoApp/Network/ImageDownload/ImageRequestOperation.swift
@@ -3,7 +3,7 @@ import UIKit
 import JNetworkingKit
 
 class ImageOperation: NSObject, RequestOperationType {
-    typealias Result = UIImage
+    typealias Result = ImageParser.Result
 
     var executor = RequestExecutor()
     var parser = ImageParser()

--- a/DemoApp/DemoApp/Network/ImageDownload/ImageRequestParser.swift
+++ b/DemoApp/DemoApp/Network/ImageDownload/ImageRequestParser.swift
@@ -3,8 +3,10 @@ import UIKit
 import JNetworkingKit
 
 class ImageParser: RequestParserType {
-    func parse(data: Data) throws -> UIImage {
-        guard let image = UIImage(data: data) else {
+    typealias Result = UIImage
+
+    func parse(response: Response) throws -> UIImage {
+        guard let image = UIImage(data: response.data) else {
             throw RequestParserError.invalidData(parserError: nil)
         }
 

--- a/DemoApp/DemoApp/Network/MovieDownload/MovieDetail/MovieDetailRequestOperation.swift
+++ b/DemoApp/DemoApp/Network/MovieDownload/MovieDetail/MovieDetailRequestOperation.swift
@@ -5,7 +5,7 @@ class MovieDetailRequestOperation: NSObject, RequestOperationType {
     typealias Result = Movie
 
     var executor = RequestExecutor()
-    var parser = MovieDetailRequestParser()
+    var parser = AnyRequestParser<Result>()
     var request = Request(route: MovieRouter.list)
     var validator = RequestValidator()
 }

--- a/DemoApp/DemoApp/Network/MovieDownload/MovieDetail/MovieDetailRequestParser.swift
+++ b/DemoApp/DemoApp/Network/MovieDownload/MovieDetail/MovieDetailRequestParser.swift
@@ -1,6 +1,0 @@
-import Foundation
-import JNetworkingKit
-
-class MovieDetailRequestParser: RequestParserType {
-    typealias Result = Movie
-}

--- a/DemoApp/Podfile.lock
+++ b/DemoApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JNetworkingKit (2.0.0)
+  - JNetworkingKit (2.0.1)
 
 DEPENDENCIES:
   - JNetworkingKit (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  JNetworkingKit: 6c091a86807a63bcaf7236fae7e1b05da437f954
+  JNetworkingKit: 54a4c931b97a1532ce70dc0f244f80b6aa079c91
 
 PODFILE CHECKSUM: f3be8929db390282be11f0be3ddf6cd16596ad7e
 

--- a/DemoApp/Pods/Local Podspecs/JNetworkingKit.podspec.json
+++ b/DemoApp/Pods/Local Podspecs/JNetworkingKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "JNetworkingKit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "summary": "A generic networking setup for Swift and Objective-C.",
   "license": {
     "type": "MIT",
@@ -15,7 +15,7 @@
   },
   "source": {
     "git": "https://github.com/jumbo-tech-campus/JNetworkingKit.git",
-    "tag": "2.0.0"
+    "tag": "2.0.1"
   },
   "source_files": "JNetworkingKit/Source/**/*.{swift}"
 }

--- a/DemoApp/Pods/Manifest.lock
+++ b/DemoApp/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JNetworkingKit (2.0.0)
+  - JNetworkingKit (2.0.1)
 
 DEPENDENCIES:
   - JNetworkingKit (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  JNetworkingKit: 6c091a86807a63bcaf7236fae7e1b05da437f954
+  JNetworkingKit: 54a4c931b97a1532ce70dc0f244f80b6aa079c91
 
 PODFILE CHECKSUM: f3be8929db390282be11f0be3ddf6cd16596ad7e
 

--- a/DemoApp/Pods/Target Support Files/JNetworkingKit/JNetworkingKit-Info.plist
+++ b/DemoApp/Pods/Target Support Files/JNetworkingKit/JNetworkingKit-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.0.0</string>
+  <string>2.0.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/JNetworkingKit.podspec
+++ b/JNetworkingKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name    = "JNetworkingKit"
-  s.version = "2.0.0"
+  s.version = "2.0.1"
   s.summary = "A generic networking setup for Swift and Objective-C."
   s.license = {
     :type => 'MIT', :text => <<-LICENSE

--- a/JNetworkingKit/JNetworkingKitTests/Mocks/RequestParserMock.swift
+++ b/JNetworkingKit/JNetworkingKitTests/Mocks/RequestParserMock.swift
@@ -25,8 +25,10 @@ class RequestParserMock {
 }
 
 extension RequestParserMock: RequestParserType {
-    func parse(data: Data) throws -> String {
-        captures.parse = Captures.Parse(data: data)
+    typealias Result = String
+
+    func parse(response: Response) throws -> String {
+        captures.parse = Captures.Parse(data: response.data)
 
         if let error = stubs.parse.error {
             throw error

--- a/JNetworkingKit/JNetworkingKitTests/Tests/Components/RequestOperationTypeSpec.swift
+++ b/JNetworkingKit/JNetworkingKitTests/Tests/Components/RequestOperationTypeSpec.swift
@@ -140,7 +140,7 @@ class RequestOperationTypeSpec: QuickSpec {
 }
 
 class ConcreteRequestOperation: RequestOperationType {
-    typealias Result = String
+    typealias Result = RequestParserMock.Result
 
     var executor: RequestExecutorMock
     var parser: RequestParserMock

--- a/JNetworkingKit/Source/Components/RequestOperation/RequestOperationType.swift
+++ b/JNetworkingKit/Source/Components/RequestOperation/RequestOperationType.swift
@@ -23,7 +23,7 @@ public extension RequestOperationType {
             onSuccess: { response in
                 do {
                     try self.validator.validate(response: response)
-                    let result = try self.parser.parse(data: response.data)
+                    let result = try self.parser.parse(response: response)
                     DispatchQueue.main.async {
                         onSuccess?(result)
                     }

--- a/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Codable.swift
+++ b/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Codable.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public extension RequestParserType where Result: Codable {
-    public func parse(data: Data) throws -> Result {
+    public func parse(response: Response) throws -> Result {
         do {
-            return try JSONDecoder().decode(Result.self, from: data)
+            return try JSONDecoder().decode(Result.self, from: response.data)
         } catch let error {
             throw RequestParserError.invalidData(parserError: error)
         }

--- a/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Codable.swift
+++ b/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Codable.swift
@@ -9,3 +9,8 @@ public extension RequestParserType where Result: Codable {
         }
     }
 }
+
+public class AnyRequestParser<ResultType: Codable>: RequestParserType {
+    public typealias Result = ResultType
+    public init() {}
+}

--- a/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Void.swift
+++ b/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Void.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public extension RequestParserType where Result == Void {
-    public func parse(data: Data) throws {}
+    public func parse(response: Response) throws {}
 }

--- a/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Void.swift
+++ b/JNetworkingKit/Source/Components/RequestParser/Extensions/RequestParserType+Void.swift
@@ -3,3 +3,8 @@ import Foundation
 public extension RequestParserType where Result == Void {
     public func parse(response: Response) throws {}
 }
+
+public class VoidRequestParser: RequestParserType {
+    public typealias Result = Void
+    public init() {}
+}

--- a/JNetworkingKit/Source/Components/RequestParser/RequestParserType.swift
+++ b/JNetworkingKit/Source/Components/RequestParser/RequestParserType.swift
@@ -8,5 +8,5 @@ public enum RequestParserError: Error {
 public protocol RequestParserType {
     associatedtype Result
 
-    func parse(data: Data) throws -> Result
+    func parse(response: Response) throws -> Result
 }

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Keys in this proposal are:
 
 * Only 1 class will execute requests
 * Only 1 class will parse requests
+* Only 1 class will validate requests
 * `RequestExecutor` can be extended easily
 * `RequestClient` can be extended easily
 * `RequestParser` can be extended easily
+* `RequestValidator` can be extended easily
 
 The proposal is build upon:
 
@@ -21,7 +23,7 @@ Together they make the code fully testable and can be developed & expanded test-
 
 ## Architecture
 
-The architecture has 7 different entities, that are defined at *Application level* (your application) or *Library level* (the library itself).
+The architecture has 8 different entities, that are defined at *Application level* (your application) or *Library level* (the library itself).
 
 #### Application level
 
@@ -76,6 +78,7 @@ extension Gateway: UserGateway {
 * **`RequestOperation`**: responsible to provide and manage the correct instances of `Request`, `Executor` and `Parser`.
 * **`RequestExecutor`**: responsible to perform the request using the correct `Client`. An extended version of the Executor can be used to add more business logic, like caching or the observable pattern.
 * **`RequestClient`**: responsible to execute the request. The default `Client` uses the `URLSession` component, but a different `Client` can be created to use different system or libraries (like _Alamofire_).
+* **`RequestValidator`**: responsible to perform the validation of the request. The default implementation checks for the response code, but you can validate header or body as well.
 * **`RequestParser`**: responsible to parse the response and create the final object.
 
 The library is designed around the `RequestOperation`. It defines its variable using **swift's generics**, in this way a developer can instantiate and use different `RequestExecutor`, `RequestClient` and `RequestParser` instances to add more functionality and capabilities to the Network Layer.
@@ -119,6 +122,7 @@ class MovieDetailRequestOperation: NSObject, RequestOperationType {
 
     var executor = RequestExecutor()
     var parser = MovieDetailRequestParser()
+    var validator = RequestValidator()
     var request = Request(route: MovieRouter.list)
 }
 ```


### PR DESCRIPTION
With the introduction of the generic `AnyRequestParser`, there is no need to create your own Parser for every operation in case it uses the `Codable` feature, just use a `AnyRequestParser` specifying the expected result type and you are ready to go.