### PR TITLE
Bump to 4.0.0 due to breaking changes to support xcode 15

### DIFF
--- a/JNetworkingKit.podspec
+++ b/JNetworkingKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name    = "JNetworkingKit"
-  s.version = "3.3.0"
+  s.version = "4.0.0"
   s.summary = "A generic networking setup for Swift and Objective-C."
   s.license = {
     :type => 'MIT', :text => <<-LICENSE


### PR DESCRIPTION
Since we needed to update the minimum iOS version supported to account for Xcode 15, it was a breaking change, justifying a major version change.